### PR TITLE
Mock tight_layout in scatterplot LaTeX test to fix CI

### DIFF
--- a/tests/plotting/test_plots.py
+++ b/tests/plotting/test_plots.py
@@ -483,9 +483,12 @@ def test_annotate_period_bins_adds_two_text_elements() -> None:
 # ---------------------------------------------------------------------------
 
 
+@patch("blipss.plotting.plots.plt.tight_layout")
 @patch("blipss.plotting.plots._save_and_close")
 @patch("blipss.plotting.plots._require_latex")
-def test_scatterplot_calls_require_latex_when_use_latex_true(mock_require: MagicMock, mock_save: MagicMock) -> None:
+def test_scatterplot_calls_require_latex_when_use_latex_true(
+    mock_require: MagicMock, mock_save: MagicMock, mock_tight_layout: MagicMock
+) -> None:
     """scatterplot_period_radiofreq calls _require_latex when use_latex is True."""
     scatterplot_period_radiofreq(
         np.array([1.0, 2.0]),
@@ -500,6 +503,7 @@ def test_scatterplot_calls_require_latex_when_use_latex_true(mock_require: Magic
         use_latex=True,
     )
     mock_require.assert_called_once()
+    mock_tight_layout.assert_called_once()
     mock_save.assert_called_once_with("out/plot", [".png"])
 
 


### PR DESCRIPTION
## Why

- The `tests` CI job (`.github/workflows/main.yml`) runs on `ubuntu-latest`, which has no LaTeX/TeX Live installation.
- `test_scatterplot_calls_require_latex_when_use_latex_true` mocks `_require_latex` (the availability guard) but not matplotlib's real text-rendering path, so it was failing in CI with:
  ```RuntimeError: Failed to process string with tex because latex could not be found```
- Root cause: with `use_latex=True`, `scatterplot_period_radiofreq` sets `rcParams['text.usetex'] = True` and then calls `plt.tight_layout()`, which eagerly computes text-artist extents via a real `latex`/`dvipng` invocation — independent of the mocked `_require_latex` check.
- The test's intent (per its name/docstring) is a narrow unit test of control flow — "calls `_require_latex` when `use_latex=True`" — not an integration test of real TeX rendering. Sibling tests (`test_candverf_plot_calls_require_latex_when_use_latex_true`, `test_plot_phase_resolved_dynamic_spectrum_calls_require_latex_when_use_latex_true`) already avoid a real draw pass and pass fine, since neither underlying function performs an eager `tight_layout()` call.
- Installing TeX Live packages in CI was considered but rejected: it adds real cost (large download, slower runs) just to make a unit test behave like an integration test, and doesn't match the test's own intent.

## What

- Added `@patch("blipss.plotting.plots.plt.tight_layout")` to `test_scatterplot_calls_require_latex_when_use_latex_true` in `tests/plotting/test_plots.py`, so the eager text-layout pass never runs and no real LaTeX binary is required.
- Asserted `mock_tight_layout.assert_called_once()`, keeping the test consistent with the "assert every mock" convention already used in the sibling `candverf_plot` test.
- No production code changes — `blipss/plotting/plots.py` behavior is untouched; only the test's isolation from the real matplotlib/TeX draw path was fixed.
- Verified locally: `tests/plotting` (57 tests) and the full suite (`uv run pytest tests --cov --cov-config=pyproject.toml`, 300 tests) both pass.