### PR TITLE
Fix/cap setuptools blimpy pkg resources

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      # blimpy 2.1.4 (latest release) imports pkg_resources, removed in setuptools 82+.
+      # Remove this ignore once UCBerkeleySETI/blimpy#281 lands in a release.
+      - dependency-name: "setuptools"
+        versions: [">=82.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,9 @@ dev = [
     "pytest>=7.2.0",
     "ruff>=0.11.5",
     "scipy>=1.17.1",
-    "setuptools>=68.0.0,<80.0.0",
+    # Capped below 82.0.0: blimpy 2.1.4 imports pkg_resources, removed in setuptools 82+.
+    # Lift once UCBerkeleySETI/blimpy#281 lands in a release. See issue #<TODO>.
+    "setuptools>=81.0.0,<82.0.0",
     "tox-uv>=1.11.3",
     "ty>=0.0.1a16",
     "types-pyyaml>=6.0.12.20260518",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "ruff>=0.11.5",
     "scipy>=1.17.1",
     # Capped below 82.0.0: blimpy 2.1.4 imports pkg_resources, removed in setuptools 82+.
-    # Lift once UCBerkeleySETI/blimpy#281 lands in a release. See issue #<TODO>.
+    # Lift once UCBerkeleySETI/blimpy#281 lands in a release. See issue #10.
     "setuptools>=81.0.0,<82.0.0",
     "tox-uv>=1.11.3",
     "ty>=0.0.1a16",

--- a/uv.lock
+++ b/uv.lock
@@ -169,7 +169,7 @@ dev = [
     { name = "pytest", specifier = ">=7.2.0" },
     { name = "ruff", specifier = ">=0.11.5" },
     { name = "scipy", specifier = ">=1.17.1" },
-    { name = "setuptools", specifier = ">=68.0.0,<80.0.0" },
+    { name = "setuptools", specifier = ">=81.0.0,<82.0.0" },
     { name = "tox-uv", specifier = ">=1.11.3" },
     { name = "ty", specifier = ">=0.0.1a16" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
@@ -1906,11 +1906,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "79.0.1"
+version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bb/71/b6365e6325b3290e14957b2c3a804a529968c77a049b2ed40c095f749707/setuptools-79.0.1.tar.gz", hash = "sha256:128ce7b8f33c3079fd1b067ecbb4051a66e8526e7b65f6cec075dfc650ddfa88", size = 1367909, upload-time = "2025-04-23T22:20:59.241Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/1c/73e719955c59b8e424d015ab450f51c0af856ae46ea2da83eba51cc88de1/setuptools-81.0.0.tar.gz", hash = "sha256:487b53915f52501f0a79ccfd0c02c165ffe06631443a886740b91af4b7a5845a", size = 1198299, upload-time = "2026-02-06T21:10:39.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/6d/b4752b044bf94cb802d88a888dc7d288baaf77d7910b7dedda74b5ceea0c/setuptools-79.0.1-py3-none-any.whl", hash = "sha256:e147c0549f27767ba362f9da434eab9c5dc0045d5304feb602a0af001089fc51", size = 1256281, upload-time = "2025-04-23T22:20:56.768Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/e3/c164c88b2e5ce7b24d667b9bd83589cf4f3520d97cad01534cd3c4f55fdb/setuptools-81.0.0-py3-none-any.whl", hash = "sha256:fdd925d5c5d9f62e4b74b30d6dd7828ce236fd6ed998a08d81de62ce5a6310d6", size = 1062021, upload-time = "2026-02-06T21:10:37.175Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
- `blimpy` 2.1.4 (our declared minimum, and the latest release) imports `pkg_resources` at module load
- `setuptools` removed `pkg_resources` in 82.0.0, so any bump past that breaks `import blimpy`
- The dependabot PR bumping setuptools to 83.0.0 can't be merged as a result. Tracked in #10, blocked on upstream fix `UCBerkeleySETI/blimpy#281`

## What
- Narrow the `setuptools` dev-group pin to `>=81.0.0,<82.0.0` and document why inline
- Add `.github/dependabot.yml` to stop dependabot re-proposing setuptools bumps `>=82.0.0`
- Update `uv.lock` to match the new pin