### PR TITLE
Add CI status and coverage badges, post coverage report on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -36,3 +39,8 @@ jobs:
 
       - name: Run tests
         run: uv run python -m pytest tests --cov --cov-config=pyproject.toml
+
+      - name: Post coverage comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![AJ Paper](https://img.shields.io/badge/DOI-10.3847/1538--3881/acccf0-blue)](https://doi.org/10.3847/1538-3881/acccf0)
 [![arXiv](http://img.shields.io/badge/astro.ph-2305.18527-B31B1B.svg)](https://arxiv.org/abs/2305.18527)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UCBerkeleySETI/blipss/blob/main/LICENSE)
+[![Tests](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml/badge.svg)](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/UCBerkeleySETI/blipss/python-coverage-comment-action-data/badge.json)](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml)
 
 The Breakthrough Listen Investigation for Periodic Spectral Signals (BLIPSS) targets the detection of narrowband periodic radar transmissions from potential technologically advanced alien life forms residing in the Universe. See this [link](http://www.mobileradar.org/radar_descptn_3.html) for examples of historic terrestrial radar operating at different radio frequencies.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,3 +135,4 @@ skip_empty = true
 [tool.coverage.run]
 branch = true
 source = ["blipss"]
+relative_files = true


### PR DESCRIPTION
Adds Tests and Coverage badges to the README, and wires up py-cov-action/python-coverage-comment-action in the tests workflow to post/update a coverage report comment on PRs into main.
