### PR TITLE
Fix coverage badge URL to point at endpoint.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-python-env
 
       - name: Run tests
-        run: uv run pytest tests --cov --cov-config=pyproject.toml
+        run: uv run python -m pytest tests --cov --cov-config=pyproject.toml
 
       - name: Post coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         uses: ./.github/actions/setup-python-env
 
       - name: Run tests
-        run: uv run python -m pytest tests --cov --cov-config=pyproject.toml
+        run: uv run pytest tests --cov --cov-config=pyproject.toml
 
       - name: Post coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![arXiv](http://img.shields.io/badge/astro.ph-2305.18527-B31B1B.svg)](https://arxiv.org/abs/2305.18527)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](https://github.com/UCBerkeleySETI/blipss/blob/main/LICENSE)
 [![Tests](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml/badge.svg)](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/UCBerkeleySETI/blipss/python-coverage-comment-action-data/badge.json)](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/UCBerkeleySETI/blipss/python-coverage-comment-action-data/endpoint.json)](https://github.com/UCBerkeleySETI/blipss/actions/workflows/main.yml)
 
 The Breakthrough Listen Investigation for Periodic Spectral Signals (BLIPSS) targets the detection of narrowband periodic radar transmissions from potential technologically advanced alien life forms residing in the Universe. See this [link](http://www.mobileradar.org/radar_descptn_3.html) for examples of historic terrestrial radar operating at different radio frequencies.
 


### PR DESCRIPTION
The python-coverage-comment-action writes endpoint.json (and badge.svg) to the data branch, not badge.json, so the shields.io endpoint badge was 404ing.