### PR TITLE
Refactor/read candidates csv pandas

### DIFF
--- a/blipss/io/read_candidates.py
+++ b/blipss/io/read_candidates.py
@@ -1,10 +1,10 @@
 """Read utilities for FFA candidate detection CSV files."""
 
-import csv
 from pathlib import Path
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 
 from blipss.constants import FFA_CANDIDATE_CSV_COLUMNS
 
@@ -45,16 +45,12 @@ def read_candidates_csv(
     Raises:
         ValueError: When the file header is missing one of ``FFA_CANDIDATE_CSV_COLUMNS``.
     """
-    with csv_path.open(newline="") as f:
-        header = next(csv.reader(f))
-    col = [header.index(name) for name in FFA_CANDIDATE_CSV_COLUMNS]
-    data = np.loadtxt(csv_path, delimiter=",", skiprows=1, usecols=col, dtype=_CANDIDATE_DTYPE, ndmin=1)
-    return (
-        data["channels"],
-        data["radiofreqs"],
-        data["phase_bins"],
-        data["boxcar_widths"],
-        data["periods"],
-        data["snrs"],
-        data["flags"],
+    df = pd.read_csv(csv_path)
+    missing = [name for name in FFA_CANDIDATE_CSV_COLUMNS if name not in df.columns]
+    if missing:
+        raise ValueError(f"Missing required column(s) in {csv_path}: {missing}")
+    channels, radiofreqs, phase_bins, boxcar_widths, periods, snrs, flags = (
+        df[name].to_numpy(dtype=dtype)
+        for name, (_, dtype) in zip(FFA_CANDIDATE_CSV_COLUMNS, _CANDIDATE_DTYPE, strict=True)
     )
+    return channels, radiofreqs, phase_bins, boxcar_widths, periods, snrs, flags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blipss"
-version = "1.2.0"
+version = "1.2.1"
 description = "Breakthrough Listen Investigation for Periodic Spectral Signals"
 authors = [{ name = "Akshay Suresh", email = "akshay721@gmail.com" }]
 readme = "README.md"

--- a/tests/io/test_read_candidates.py
+++ b/tests/io/test_read_candidates.py
@@ -73,5 +73,5 @@ def test_read_candidates_csv_missing_column_raises_value_error(tmp_path: Path) -
     incomplete_header = [c for c in FFA_CANDIDATE_CSV_COLUMNS if c != "S/N"]
     _write_csv(csv_path, incomplete_header, [])
 
-    with pytest.raises(ValueError, match="not in list"):
+    with pytest.raises(ValueError, match="S/N"):
         read_candidates_csv(csv_path)

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "blipss"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "blimpy" },


### PR DESCRIPTION
## Why

- `np.loadtxt` is a heavier, less idiomatic tool than `pandas` for reading tabular CSV data, and the codebase already depends on pandas elsewhere.
- Switching to `pd.read_csv` also gives a clearer error message when a required column is missing from the header.

## What

- Replaced `np.loadtxt` with `pd.read_csv` in `read_candidates_csv` (`blipss/io/read_candidates.py`), selecting and reordering columns by name per `FFA_CANDIDATE_CSV_COLUMNS`, then casting each to the same dtypes as before.
- Return values, column order, and function signature are unchanged.
- Missing-column handling now raises `ValueError` with the specific missing column name(s) instead of `np.loadtxt`'s generic `"not in list"` message.
- Updated the corresponding unit test (`tests/io/test_read_candidates.py`) to match the new error message.
- Bumped `pyproject.toml` version `1.2.0` → `1.2.1` (patch bump; internal refactor, no public API or behavior change).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / code quality
- [ ] Other

## Checklist

- [x] I have added or updated tests that cover my changes.
- [x] `make check` passes locally (formatting, linting, type checking).
- [x] `make test` passes locally.
- [ ] I have updated `README.md` if this PR adds or changes CLI functionality.
- [x] I have updated relevant docstrings/documentation.
- [x] If this PR contains code changes, I have incremented the version number in `pyproject.toml` following semantic versioning.